### PR TITLE
Remove keepalive params from Pickaxe

### DIFF
--- a/grpc/connection.go
+++ b/grpc/connection.go
@@ -4,12 +4,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"strings"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/keepalive"
 )
 
 func GetGrpcConnection(grpcUri string) (*grpc.ClientConn, error) {
@@ -30,11 +28,6 @@ func GetGrpcConnection(grpcUri string) (*grpc.ClientConn, error) {
 	// Set up gRPC dial options with custom keep alive and timeout values
 	opts := []grpc.DialOption{
 		transportCredentials,
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                10 * time.Second,
-			Timeout:             5 * time.Second,
-			PermitWithoutStream: true,
-		}),
 	}
 
 	return grpc.Dial(


### PR DESCRIPTION
Using these params definitely keeps an open connection, but the server sends a lot of `goaway`s and there's no reason to be cruel to our poor nodes. 