### PR TITLE
Various Fixes & Features

### DIFF
--- a/arrays/batch_test.go
+++ b/arrays/batch_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/tessellated-io/pickaxe/arrays"
 )
 
+func TestBatch_OneSizeBatch(t *testing.T) {
+	arr := []int{1, 2}
+	batched := arrays.Batch(arr, 1)
+
+	require.Equal(t, len(batched), 2)
+
+	require.Equal(t, len(batched[0]), 1)
+	require.Equal(t, len(batched[1]), 1)
+
+	require.Equal(t, batched[0][0], 1)
+	require.Equal(t, batched[1][0], 2)
+}
+
 func TestBatch_EvenBatches(t *testing.T) {
 	arr := []int{1, 2, 3, 4}
 	batched := arrays.Batch(arr, 2)

--- a/cosmos/chain-registry/asset_list.go
+++ b/cosmos/chain-registry/asset_list.go
@@ -1,0 +1,91 @@
+package registry
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type AssetList struct {
+	Schema    string  `json:"$schema"`
+	ChainName string  `json:"chain_name"`
+	Assets    []Asset `json:"assets"`
+}
+
+type Asset struct {
+	Description string       `json:"description"`
+	DenomUnits  []DenomUnit  `json:"denom_units"`
+	Base        string       `json:"base"`
+	Name        string       `json:"name"`
+	Display     string       `json:"display"`
+	Symbol      string       `json:"symbol"`
+	LogoURIs    LogoURIs     `json:"logo_URIs"`
+	CoingeckoID string       `json:"coingecko_id"`
+	Images      []ImageLinks `json:"images"`
+}
+
+type DenomUnit struct {
+	Denom    string `json:"denom"`
+	Exponent int    `json:"exponent"`
+}
+
+type ImageLinks struct {
+	Png string `json:"png"`
+	Svg string `json:"svg"`
+}
+
+func parseAssetListResponse(assetListBytes []byte) (*AssetList, error) {
+	// Unmarshal JSON data
+	var assetList AssetList
+	if err := json.Unmarshal(assetListBytes, &assetList); err != nil {
+		return nil, err
+	}
+	return &assetList, nil
+}
+
+// Convenience methods
+
+func (al *AssetList) ExtractAssetByBaseSymbol(baseAssetSymbol string) (*Asset, error) {
+	assets := al.Assets
+	for _, asset := range assets {
+		if strings.EqualFold(asset.Base, baseAssetSymbol) {
+			return &asset, nil
+		}
+	}
+	return nil, ErrNoMatchingAsset
+}
+
+func (a *Asset) ExtractDenomByUnit(needleDenomUnit string) (*DenomUnit, error) {
+	denomUnits := a.DenomUnits
+	for _, denomUnit := range denomUnits {
+		if strings.EqualFold(denomUnit.Denom, needleDenomUnit) {
+			return &denomUnit, nil
+		}
+	}
+	return nil, ErrNoMatchingDenom
+}
+
+// Get a single token, given a base symbol. Ex. 1 JUNO = sdk.Coin{ denom: "ujuno", amount: "1_000_000" }
+func (al *AssetList) OneToken(baseAssetSymbol string) (*sdk.Coin, error) {
+	// Extract the asset
+	asset, err := al.ExtractAssetByBaseSymbol(baseAssetSymbol)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the denom unit
+	denomUnit, err := asset.ExtractDenomByUnit(baseAssetSymbol)
+	if err != nil {
+		return nil, err
+	}
+
+	decimals := denomUnit.Exponent
+
+	// Create one coin.
+	oneAmount := sdk.NewInt(int64(math.Pow(10, float64(decimals))))
+	oneCoin := sdk.NewCoin(baseAssetSymbol, oneAmount)
+
+	return &oneCoin, nil
+}

--- a/cosmos/chain-registry/chain_info.go
+++ b/cosmos/chain-registry/chain_info.go
@@ -1,14 +1,7 @@
 package registry
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
-	"math"
-
-	"github.com/tessellated-io/pickaxe/cosmos/rpc"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func parseChainResponse(responseBytes []byte) (*ChainInfo, error) {
@@ -30,30 +23,6 @@ func (ci *ChainInfo) FeeDenom() (string, error) {
 	}
 
 	return feeToken.Denom, nil
-}
-
-func (ci *ChainInfo) OneFeeToken(ctx context.Context, rpcClient rpc.RpcClient) (*sdk.Coin, error) {
-	feeDenom, err := ci.FeeDenom()
-	if err != nil {
-		return nil, err
-	}
-
-	// Fetch denom metadata from the registry to get decimals. It's a bummer chain registry doesn't seem to include this field.
-	denomMetadata, err := rpcClient.GetDenomMetadata(ctx, feeDenom)
-	if err != nil {
-		return nil, err
-	}
-	denomUnits := denomMetadata.DenomUnits
-	if len(denomUnits) == 0 {
-		return nil, fmt.Errorf("no denom unit found for %s", feeDenom)
-	}
-	decimals := denomUnits[0].Exponent
-
-	// Create one coin.
-	oneAmount := sdk.NewInt(int64(math.Pow(10, float64(decimals))))
-	oneCoin := sdk.NewCoin(feeDenom, oneAmount)
-
-	return &oneCoin, nil
 }
 
 func (ci *ChainInfo) StakingDenom() (string, error) {

--- a/cosmos/chain-registry/chain_registry_client.go
+++ b/cosmos/chain-registry/chain_registry_client.go
@@ -7,6 +7,7 @@ type ChainRegistryClient interface {
 	AllChainNames(ctx context.Context) ([]string, error)
 	ChainNameForChainID(ctx context.Context, targetChainID string, refreshCache bool) (string, error)
 	ChainInfo(ctx context.Context, chainName string) (*ChainInfo, error)
+	AssetList(ctx context.Context, chainName string) (*AssetList, error)
 
 	// Restake Validator Registry
 	Validator(ctx context.Context, targetValidator string) (*Validator, error)

--- a/cosmos/chain-registry/errors.go
+++ b/cosmos/chain-registry/errors.go
@@ -6,4 +6,6 @@ var (
 	ErrNoChainFoundForChainID = errors.New("no chain found for chain ID")
 	ErrNoStakingTokenFound    = errors.New("no staking tokens found in registry")
 	ErrNoFeeTokenFound        = errors.New("no fee tokens found in registry")
+	ErrNoMatchingAsset        = errors.New("no matching asset found")
+	ErrNoMatchingDenom        = errors.New("no matching denom found")
 )

--- a/cosmos/rpc/grpc-client.go
+++ b/cosmos/rpc/grpc-client.go
@@ -159,6 +159,7 @@ func (r *grpcClient) CheckIncluded(ctx context.Context, txHash string) (bool, er
 		if ok && grpcErr.Code() == codes.NotFound {
 			return false, nil
 		} else if ok {
+			// TODO: Deleteme
 			fmt.Println("FYI, unwrapped grpc error to ", grpcErr)
 		}
 

--- a/cosmos/tx/gas.go
+++ b/cosmos/tx/gas.go
@@ -15,14 +15,16 @@ import (
 
 // GasManager interprets tx results and associated outcomes.
 type GasManager interface {
-	// Get a suggested gas price for the chainID
-	GetGasPrice(ctx context.Context, chainID string) (float64, error)
+	// Get a suggested gas price for the chainName
+	GetGasPrice(ctx context.Context, chainName string) (float64, error)
 
-	// Given a broadcast result for a chainID , update gas prices.
-	ManageBroadcastResult(ctx context.Context, chainID string, broadcastResult *txtypes.BroadcastTxResponse) error
+	// Given a broadcast result for a chainName , update gas prices.
+	ManageBroadcastResult(ctx context.Context, chainName string, broadcastResult *txtypes.BroadcastTxResponse, gasWanted uint64) error
 
-	// Update gas prices on the given chainID  with whether or not a transaction confirmed in a given time period.
-	ManageInclusionResult(ctx context.Context, chainID string, confirmed bool) error
+	// Update gas prices on the given chainName  with whether or not a transaction confirmed in a given time period.
+	ManageInclusionResult(ctx context.Context, chainName string, confirmed bool) error
+
+	SetChainRegistryClient(newClient chainregistry.ChainRegistryClient)
 }
 
 // defaultGasManager implements a naive gas management scheme.
@@ -39,8 +41,8 @@ type defaultGasManager struct {
 
 var _ GasManager = (*defaultGasManager)(nil)
 
-func NewDefaultGasManager(priceIncrement float64, gasPriceProvider GasPriceProvider, logger *log.Logger) (GasManager, error) {
-	gasLogger := logger.ApplyPrefix("⛽️ ")
+func NewDefaultGasManager(priceIncrement float64, gasPriceProvider GasPriceProvider, logger *log.Logger, chainRegistryClient chainregistry.ChainRegistryClient) (GasManager, error) {
+	gasLogger := logger.ApplyPrefix(" ⛽️")
 
 	gasManager := &defaultGasManager{
 		priceIncrement: priceIncrement,
@@ -48,24 +50,29 @@ func NewDefaultGasManager(priceIncrement float64, gasPriceProvider GasPriceProvi
 		consecutiveSuccesses: make(map[string]int),
 		lock:                 &sync.Mutex{},
 
-		gasPriceProvider: gasPriceProvider,
-		logger:           gasLogger,
+		gasPriceProvider:    gasPriceProvider,
+		chainRegistryClient: chainRegistryClient,
+		logger:              gasLogger,
 	}
 
 	return gasManager, nil
 }
 
-func (gm *defaultGasManager) GetGasPrice(ctx context.Context, chainID string) (float64, error) {
+func (gm *defaultGasManager) SetChainRegistryClient(newClient chainregistry.ChainRegistryClient) {
+	gm.chainRegistryClient = newClient
+}
+
+func (gm *defaultGasManager) GetGasPrice(ctx context.Context, chainName string) (float64, error) {
 	// Attempt to get a gas price, and return if successful.
-	gasPrice, err := gm.gasPriceProvider.GetGasPrice(chainID)
+	gasPrice, err := gm.gasPriceProvider.GetGasPrice(chainName)
 	if err == nil {
-		gm.logger.Info().Str("chain_id", chainID).Float64("gas_price", gasPrice).Msg("got gas price from cache")
+		gm.logger.Debug().Str("chain_id", chainName).Float64("gas_price", gasPrice).Msg("got gas price from cache")
 
 		return gasPrice, nil
 	}
 
 	// Otherwise, fetch the chain info, and get a gas price from it.
-	chainInfo, err := gm.chainRegistryClient.ChainInfo(ctx, chainID)
+	chainInfo, err := gm.chainRegistryClient.ChainInfo(ctx, chainName)
 	if err != nil {
 		return 0, err
 	}
@@ -75,93 +82,95 @@ func (gm *defaultGasManager) GetGasPrice(ctx context.Context, chainID string) (f
 	}
 
 	// Set it for the next run
-	err = gm.gasPriceProvider.SetGasPrice(chainID, gasPrice)
+	err = gm.gasPriceProvider.SetGasPrice(chainName, gasPrice)
 	if err != nil {
 		return 0, err
 	}
 
-	gm.logger.Info().Str("chain_name", chainID).Float64("gas_price", gasPrice).Msg("fetched gas price from chain registry")
+	gm.logger.Info().Str("chain_name", chainName).Float64("gas_price", gasPrice).Msg("fetched gas price from chain registry")
 	return gasPrice, nil
 }
 
-func (gm *defaultGasManager) ManageBroadcastResult(ctx context.Context, chainID string, broadcastResult *txtypes.BroadcastTxResponse) error {
+func (gm *defaultGasManager) ManageBroadcastResult(ctx context.Context, chainName string, broadcastResult *txtypes.BroadcastTxResponse, gasWanted uint64) error {
 	// Extract the code and logs from broadcasting
+	codespace := broadcastResult.TxResponse.Codespace
 	code := broadcastResult.TxResponse.Code
 	logs := broadcastResult.TxResponse.RawLog
 
 	// If code is 0 (success) then do nothing
 	if code == 0 {
-		gm.trackSuccess(ctx, chainID)
+		gm.trackSuccess(ctx, chainName)
 		return nil
 	}
 
-	// If code is 13 (insufficient fee) then we should adjust our gas
-	if code == 13 {
+	// If code is a gas error, we should try to adjust our gas
+	if IsGasError(codespace, code) {
 		// Get the old gas price
-		oldPrice, err := gm.GetGasPrice(ctx, chainID)
+		oldPrice, err := gm.GetGasPrice(ctx, chainName)
 		if err != nil {
 			return err
 		}
 
 		// Try to extract a fee from the error message.
 		chainSuggestedFee, err := gm.extractMinGlobalFee(logs)
-		if err != nil {
+		if err == nil {
 			// Determine the gas price by dividing the fee by the gas units requested
-			gasWanted := broadcastResult.TxResponse.GasWanted
 			if gasWanted == 0 {
 				return fmt.Errorf("gas wanted cannot be zero")
 			}
 			newGasPrice := chainSuggestedFee / float64(gasWanted)
 
 			// Set and log
-			err = gm.gasPriceProvider.SetGasPrice(chainID, newGasPrice)
+			err = gm.gasPriceProvider.SetGasPrice(chainName, newGasPrice)
 			if err != nil {
 				return err
 			}
-			gm.logger.Info().Str("chain_name", chainID).Float64("old_gas_price", oldPrice).Float64("new_gas_price", newGasPrice).Msg("updated gas price due to transaction broadcast")
+			gm.logger.Info().Str("chain_name", chainName).Float64("old_gas_price", oldPrice).Float64("new_gas_price", newGasPrice).Msg("updated gas price due to transaction broadcast failure")
 		} else {
 			// Otherwise, simply increment the fee
 			newPrice := oldPrice + gm.priceIncrement
 
 			// Set and log
-			err = gm.gasPriceProvider.SetGasPrice(chainID, newPrice)
+			err = gm.gasPriceProvider.SetGasPrice(chainName, newPrice)
 			if err != nil {
 				return err
 			}
-			gm.logger.Info().Str("chain_name", chainID).Float64("old_gas_price", oldPrice).Float64("new_gas_price", newPrice).Msg("updated gas price due to transaction broadcast")
+			gm.logger.Info().Str("chain_name", chainName).Float64("old_gas_price", oldPrice).Float64("new_gas_price", newPrice).Msg("updated gas price due to transaction broadcast failure")
 		}
 
-		gm.trackFailure(chainID)
+		gm.trackFailure(chainName)
 		return nil
+	} else if codespace == "gaia" && code == 4 {
+
 	}
 
 	// Otherwise, we got an unrelated error for broadcasting. Audibly drop it on the floor.
-	gm.logger.Info().Str("chain_name", chainID).Str("logs", logs).Uint32("code", code).Msg("transaction failed to broadcast but failure not related to gas")
+	gm.logger.Info().Str("chain_name", chainName).Str("logs", logs).Uint32("code", code).Msg("transaction failed to broadcast but failure not related to gas")
 	return nil
 }
 
 // In our naive implementation, simply bump the gas price if we didn't get a confirmation.
-func (gm *defaultGasManager) ManageInclusionResult(ctx context.Context, chainID string, confirmed bool) error {
+func (gm *defaultGasManager) ManageInclusionResult(ctx context.Context, chainName string, confirmed bool) error {
 	// Don't process further if it confirmed successfully.
 	if confirmed {
-		gm.trackSuccess(ctx, chainID)
+		gm.trackSuccess(ctx, chainName)
 		return nil
 	}
-	gm.trackFailure(chainID)
+	gm.trackFailure(chainName)
 
 	// Get the old gas price
-	oldPrice, err := gm.GetGasPrice(ctx, chainID)
+	oldPrice, err := gm.GetGasPrice(ctx, chainName)
 	if err != nil {
 		return err
 	}
 
 	// Bump price and set
 	newPrice := oldPrice + gm.priceIncrement
-	err = gm.gasPriceProvider.SetGasPrice(chainID, newPrice)
+	err = gm.gasPriceProvider.SetGasPrice(chainName, newPrice)
 	if err != nil {
 		return err
 	}
-	gm.logger.Info().Str("chain_name", chainID).Float64("old_gas_price", oldPrice).Float64("new_gas_price", newPrice).Msg("updated gas price due to failure in transaction confirmation")
+	gm.logger.Info().Str("chain_name", chainName).Float64("old_gas_price", oldPrice).Float64("new_gas_price", newPrice).Msg("updated gas price due to failure in transaction confirmation")
 
 	return nil
 }
@@ -186,55 +195,55 @@ func (gm *defaultGasManager) extractMinGlobalFee(errMsg string) (float64, error)
 }
 
 // Management functions for tracking consecutive successes
-func (gm *defaultGasManager) trackSuccess(ctx context.Context, chainID string) {
+func (gm *defaultGasManager) trackSuccess(ctx context.Context, chainName string) {
 	gm.lock.Lock()
 	defer gm.lock.Unlock()
 
 	// Increment
-	oldValue := gm.consecutiveSuccesses[chainID]
+	oldValue := gm.consecutiveSuccesses[chainName]
 	newValue := oldValue + 1
 
 	// Update the value
-	gm.consecutiveSuccesses[chainID] = newValue
+	gm.consecutiveSuccesses[chainName] = newValue
 
 	// Try to jitter the gas down.
 	consecutiveSuccessThreshold := 3
 	if newValue >= consecutiveSuccessThreshold {
 		// Get the old gas price
-		oldPrice, err := gm.GetGasPrice(ctx, chainID)
+		oldPrice, err := gm.GetGasPrice(ctx, chainName)
 		if err != nil {
-			gm.logger.Error().Err(err).Str("chain_name", chainID).Int("consecutive_successes", newValue).Msg("attempted to decrement gas but failed to fetch old price")
+			gm.logger.Error().Err(err).Str("chain_name", chainName).Int("consecutive_successes", newValue).Msg("attempted to decrement gas but failed to fetch old price")
 			return
 		}
 
 		// Decrement price, bounding for zero
-		newPrice := oldPrice - gm.priceIncrement
+		newPrice := oldPrice - (gm.priceIncrement / 2.0)
 		if newPrice < 0 {
 			newPrice = 0
 		}
 
 		// Set and log
-		err = gm.gasPriceProvider.SetGasPrice(chainID, newPrice)
+		err = gm.gasPriceProvider.SetGasPrice(chainName, newPrice)
 		if err != nil {
-			gm.logger.Error().Err(err).Str("chain_name", chainID).Int("consecutive_successes", newValue).Msg("attempted to decrement gas but failed to setnew price")
+			gm.logger.Error().Err(err).Str("chain_name", chainName).Int("consecutive_successes", newValue).Msg("attempted to decrement gas but failed to setnew price")
 			return
 		}
-		gm.logger.Info().Str("chain_name", chainID).Float64("old_gas_price", oldPrice).Int("consecutive_successes", newValue).Float64("new_gas_price", newPrice).Msg("decremented gas price because of consecutive successes")
+		gm.logger.Info().Str("chain_name", chainName).Float64("old_gas_price", oldPrice).Int("consecutive_successes", newValue).Float64("new_gas_price", newPrice).Msg("decremented gas price because of consecutive successes")
 
 	}
 }
 
-func (gm *defaultGasManager) trackFailure(chainID string) {
+func (gm *defaultGasManager) trackFailure(chainName string) {
 	gm.lock.Lock()
 	defer gm.lock.Unlock()
 
-	gm.consecutiveSuccesses[chainID] = 0
+	gm.consecutiveSuccesses[chainName] = 0
 }
 
 // GasPriceProvider is a simple KV store for gas.
 type GasPriceProvider interface {
-	GetGasPrice(chainID string) (float64, error)
-	SetGasPrice(chainID string, gasPrice float64) error
+	GetGasPrice(chainName string) (float64, error)
+	SetGasPrice(chainName string, gasPrice float64) error
 }
 
 // InMemoryGasPriceProvider stores gas prices in memory.
@@ -255,11 +264,11 @@ func NewInMemoryGasPriceProvider() (GasPriceProvider, error) {
 	return provider, nil
 }
 
-func (gp *InMemoryGasPriceProvider) GetGasPrice(chainID string) (float64, error) {
+func (gp *InMemoryGasPriceProvider) GetGasPrice(chainName string) (float64, error) {
 	gp.lock.Lock()
 	defer gp.lock.Unlock()
 
-	gasPrice, found := gp.prices[chainID]
+	gasPrice, found := gp.prices[chainName]
 	if !found {
 		return 0, ErrNoGasPrice
 	}
@@ -267,10 +276,18 @@ func (gp *InMemoryGasPriceProvider) GetGasPrice(chainID string) (float64, error)
 	return gasPrice, nil
 }
 
-func (gp *InMemoryGasPriceProvider) SetGasPrice(chainID string, gasPrice float64) error {
+func (gp *InMemoryGasPriceProvider) SetGasPrice(chainName string, gasPrice float64) error {
 	gp.lock.Lock()
 	defer gp.lock.Unlock()
 
-	gp.prices[chainID] = gasPrice
+	gp.prices[chainName] = gasPrice
 	return nil
+}
+
+// Helper function to determine if an error is related to insufficient gas
+func IsGasError(codespace string, code uint32) bool {
+	if (codespace == "sdk" && code == 13) || (codespace == "gaia" && code == 4) {
+		return true
+	}
+	return false
 }

--- a/cosmos/tx/gas.go
+++ b/cosmos/tx/gas.go
@@ -140,8 +140,6 @@ func (gm *defaultGasManager) ManageBroadcastResult(ctx context.Context, chainNam
 
 		gm.trackFailure(chainName)
 		return nil
-	} else if codespace == "gaia" && code == 4 {
-
 	}
 
 	// Otherwise, we got an unrelated error for broadcasting. Audibly drop it on the floor.

--- a/cosmos/tx/signer.go
+++ b/cosmos/tx/signer.go
@@ -9,6 +9,8 @@ import (
 // Get a signer given a SLIP44 value.
 func GetSoftSigner(slip44 uint, mnemonic string) (crypto.BytesSigner, error) {
 	switch slip44 {
+	case 564:
+		return crypto.NewKeyPairFromMnemonic(mnemonic, 564), nil
 	case 118:
 		return crypto.NewCosmosKeyPairFromMnemonic(mnemonic), nil
 	case 60:

--- a/cosmos/tx/signing_metadata_provider.go
+++ b/cosmos/tx/signing_metadata_provider.go
@@ -14,6 +14,7 @@ type SigningMetadataProvider struct {
 
 func NewSigningMetadataProvider(chainID string, rpcClient rpc.RpcClient) (*SigningMetadataProvider, error) {
 	return &SigningMetadataProvider{
+		chainID:   chainID,
 		rpcClient: rpcClient,
 	}, nil
 }


### PR DESCRIPTION
Including, but not limited to:
- Add testing to sanity check batching correctness
- Implement asset list querying from cosmos chain registry
- Remove poorly conceived `OneFeeToken` function
- Add logging for rpc / registry clients
- Fix bug with unwrapping context errors in rpc / registry clients
- Fix bug where non included txs would be retried in `checkIncluded` in grpc rpc client
- Fix various chain name / chain id mismatches in cosmos `gas` code (TODO: make a more generalized API)
- Fix bug where `chainRegistryClient` was not initialized in `defaultGasManager`'s constructor
- Explicitly pass `gasWanted` to `GasManager`. It is not populated correctly in the tx broadcast result
- Support Agoric's cointype
- Fix bug where `chainID` wasn't populated in signer metadata
- Revise `GasManager` to track codespace as well
- 