### PR TITLE
Migrate the Cosmos [Registry, Validator] Client to use Tessellated's Planetarium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-arch: ["amd64", "arm", "arm64"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go

--- a/cosmos/chain-registry/registry.go
+++ b/cosmos/chain-registry/registry.go
@@ -38,7 +38,7 @@ func NewChainRegistryClient(log *log.Logger) *chainRegistryClient {
 // ChainRegistryClient interface
 
 func (rc *chainRegistryClient) ChainInfo(ctx context.Context, chainName string) (*ChainInfo, error) {
-	url := fmt.Sprintf("https://registry.ping.pub//%s/chain.json", chainName)
+	url := fmt.Sprintf("https://registry.ping.pub/%s/chain.json", chainName)
 
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {
@@ -57,7 +57,7 @@ func (rc *chainRegistryClient) ChainInfo(ctx context.Context, chainName string) 
 }
 
 func (rc *chainRegistryClient) AssetList(ctx context.Context, chainName string) (*AssetList, error) {
-	url := fmt.Sprintf("https://registry.ping.pub//%s/assetlist.json", chainName)
+	url := fmt.Sprintf("https://registry.ping.pub/%s/assetlist.json", chainName)
 
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {
@@ -178,6 +178,7 @@ func (rc *chainRegistryClient) makeRequest(ctx context.Context, url string) ([]b
 	if err != nil {
 		return nil, err
 	}
+	request.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(request)

--- a/cosmos/chain-registry/registry.go
+++ b/cosmos/chain-registry/registry.go
@@ -38,7 +38,7 @@ func NewChainRegistryClient(log *log.Logger) *chainRegistryClient {
 // ChainRegistryClient interface
 
 func (rc *chainRegistryClient) ChainInfo(ctx context.Context, chainName string) (*ChainInfo, error) {
-	url := fmt.Sprintf("https://proxy.atomscan.com/directory/%s/chain.json", chainName)
+	url := fmt.Sprintf("https://registry.ping.pub//%s/chain.json", chainName)
 
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {
@@ -57,7 +57,7 @@ func (rc *chainRegistryClient) ChainInfo(ctx context.Context, chainName string) 
 }
 
 func (rc *chainRegistryClient) AssetList(ctx context.Context, chainName string) (*AssetList, error) {
-	url := fmt.Sprintf("https://proxy.atomscan.com/directory/%s/assetlist.json", chainName)
+	url := fmt.Sprintf("https://registry.ping.pub//%s/assetlist.json", chainName)
 
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {

--- a/cosmos/chain-registry/registry.go
+++ b/cosmos/chain-registry/registry.go
@@ -158,7 +158,7 @@ func (rc *chainRegistryClient) AllChainNames(ctx context.Context) ([]string, err
 }
 
 func (rc *chainRegistryClient) Validator(ctx context.Context, targetValidator string) (*Validator, error) {
-	url := fmt.Sprintf("%s/%s", rc.validatorRegistryBaseUrl, targetValidator)
+	url := fmt.Sprintf("%s/%s/chains.json", rc.validatorRegistryBaseUrl, targetValidator)
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {
 		return nil, err

--- a/cosmos/chain-registry/registry.go
+++ b/cosmos/chain-registry/registry.go
@@ -36,7 +36,7 @@ type chainRegistryClient struct {
 var _ ChainRegistryClient = (*chainRegistryClient)(nil)
 
 // NewRegistryClient makes a new default registry client.
-func NewChainRegistryClient(log *log.Logger, chainRegistryBaseUrl string, validatorRegistryBaseUrl string) *chainRegistryClient {
+func NewChainRegistryClient(log *log.Logger, chainRegistryBaseUrl, validatorRegistryBaseUrl string) *chainRegistryClient {
 	return &chainRegistryClient{
 		// Initially empty chain name cache
 		chainNames:         []string{},

--- a/cosmos/chain-registry/registry.go
+++ b/cosmos/chain-registry/registry.go
@@ -52,7 +52,7 @@ func NewChainRegistryClient(log *log.Logger, chainRegistryBaseUrl string, valida
 // ChainRegistryClient interface
 
 func (rc *chainRegistryClient) ChainInfo(ctx context.Context, chainName string) (*ChainInfo, error) {
-	url := fmt.Sprintf("%s/%s/chain.json ", rc.chainRegistryBaseUrl, chainName)
+	url := fmt.Sprintf("%s/%s/chain.json", rc.chainRegistryBaseUrl, chainName)
 
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {

--- a/cosmos/chain-registry/registry.go
+++ b/cosmos/chain-registry/registry.go
@@ -18,6 +18,9 @@ type chainRegistryClient struct {
 	// Cache of chain names to chain ID
 	chainNameToChainID map[string]string
 
+	// Base url of an API service
+	baseURL string
+
 	log *log.Logger
 }
 
@@ -25,11 +28,13 @@ type chainRegistryClient struct {
 var _ ChainRegistryClient = (*chainRegistryClient)(nil)
 
 // NewRegistryClient makes a new default registry client.
-func NewChainRegistryClient(log *log.Logger) *chainRegistryClient {
+func NewChainRegistryClient(log *log.Logger, baseURL string) *chainRegistryClient {
 	return &chainRegistryClient{
 		// Initially empty chain name cache
 		chainNames:         []string{},
 		chainNameToChainID: make(map[string]string),
+
+		baseURL: baseURL,
 
 		log: log,
 	}
@@ -38,7 +43,7 @@ func NewChainRegistryClient(log *log.Logger) *chainRegistryClient {
 // ChainRegistryClient interface
 
 func (rc *chainRegistryClient) ChainInfo(ctx context.Context, chainName string) (*ChainInfo, error) {
-	url := fmt.Sprintf("https://registry.ping.pub/%s/chain.json", chainName)
+	url := fmt.Sprintf("%s/v1/chain/%s", rc.baseURL, chainName)
 
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {
@@ -57,7 +62,7 @@ func (rc *chainRegistryClient) ChainInfo(ctx context.Context, chainName string) 
 }
 
 func (rc *chainRegistryClient) AssetList(ctx context.Context, chainName string) (*AssetList, error) {
-	url := fmt.Sprintf("https://registry.ping.pub/%s/assetlist.json", chainName)
+	url := fmt.Sprintf("%s/v1/chain/%s/assets", rc.baseURL, chainName)
 
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {
@@ -129,7 +134,7 @@ func (rc *chainRegistryClient) ChainNameForChainID(ctx context.Context, targetCh
 
 func (rc *chainRegistryClient) AllChainNames(ctx context.Context) ([]string, error) {
 	// Get all chain names
-	url := "https://cosmoschains.thesilverfox.pro/api/v1/mainnet"
+	url := fmt.Sprintf("%s/v1/chains", rc.baseURL)
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {
 		return nil, err

--- a/cosmos/chain-registry/registry.go
+++ b/cosmos/chain-registry/registry.go
@@ -10,6 +10,13 @@ import (
 	"github.com/tessellated-io/pickaxe/log"
 )
 
+/**
+ * A chain registry client.
+ *
+ * This class is made to be compatible with Planetarium (https://github.com/tessellated-io/planetarium), which is a hosted version
+ * of the Chain Registry provided by Tessellated, although it should be compatible with other services by providing custom base urls.
+ */
+
 // Default implementation
 type chainRegistryClient struct {
 	// Cache of all chain names
@@ -19,7 +26,8 @@ type chainRegistryClient struct {
 	chainNameToChainID map[string]string
 
 	// Base url of an API service
-	baseURL string
+	chainRegistryBaseUrl     string
+	validatorRegistryBaseUrl string
 
 	log *log.Logger
 }
@@ -28,13 +36,14 @@ type chainRegistryClient struct {
 var _ ChainRegistryClient = (*chainRegistryClient)(nil)
 
 // NewRegistryClient makes a new default registry client.
-func NewChainRegistryClient(log *log.Logger, baseURL string) *chainRegistryClient {
+func NewChainRegistryClient(log *log.Logger, chainRegistryBaseUrl string, validatorRegistryBaseUrl string) *chainRegistryClient {
 	return &chainRegistryClient{
 		// Initially empty chain name cache
 		chainNames:         []string{},
 		chainNameToChainID: make(map[string]string),
 
-		baseURL: baseURL,
+		chainRegistryBaseUrl:     chainRegistryBaseUrl,
+		validatorRegistryBaseUrl: validatorRegistryBaseUrl,
 
 		log: log,
 	}
@@ -43,7 +52,7 @@ func NewChainRegistryClient(log *log.Logger, baseURL string) *chainRegistryClien
 // ChainRegistryClient interface
 
 func (rc *chainRegistryClient) ChainInfo(ctx context.Context, chainName string) (*ChainInfo, error) {
-	url := fmt.Sprintf("%s/v1/chain/%s", rc.baseURL, chainName)
+	url := fmt.Sprintf("%s/%s/chain.json ", rc.chainRegistryBaseUrl, chainName)
 
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {
@@ -62,7 +71,7 @@ func (rc *chainRegistryClient) ChainInfo(ctx context.Context, chainName string) 
 }
 
 func (rc *chainRegistryClient) AssetList(ctx context.Context, chainName string) (*AssetList, error) {
-	url := fmt.Sprintf("%s/v1/chain/%s/assets", rc.baseURL, chainName)
+	url := fmt.Sprintf("%s/%s/assetlist.json", rc.chainRegistryBaseUrl, chainName)
 
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {
@@ -134,7 +143,7 @@ func (rc *chainRegistryClient) ChainNameForChainID(ctx context.Context, targetCh
 
 func (rc *chainRegistryClient) AllChainNames(ctx context.Context) ([]string, error) {
 	// Get all chain names
-	url := fmt.Sprintf("%s/v1/chains", rc.baseURL)
+	url := fmt.Sprintf("%s/all", rc.chainRegistryBaseUrl)
 	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {
 		return nil, err
@@ -149,29 +158,17 @@ func (rc *chainRegistryClient) AllChainNames(ctx context.Context) ([]string, err
 }
 
 func (rc *chainRegistryClient) Validator(ctx context.Context, targetValidator string) (*Validator, error) {
-	validators, err := rc.Validators(ctx)
+	url := fmt.Sprintf("%s/%s", rc.validatorRegistryBaseUrl, targetValidator)
+	bytes, err := rc.makeRequest(ctx, url)
 	if err != nil {
 		return nil, err
 	}
 
-	validator, err := rc.extractValidator(targetValidator, validators)
+	response, err := parseValidator(bytes)
 	if err != nil {
 		return nil, err
 	}
-	return validator, nil
-}
-
-func (rc *chainRegistryClient) Validators(ctx context.Context) ([]Validator, error) {
-	bytes, err := rc.makeRequest(ctx, "https://validators.cosmos.directory/")
-	if err != nil {
-		return nil, err
-	}
-
-	response, err := parseValidatorRegistryResponse(bytes)
-	if err != nil {
-		return nil, err
-	}
-	return response.Validators, nil
+	return response, nil
 }
 
 // Private helpers
@@ -208,13 +205,4 @@ func (rc *chainRegistryClient) makeRequest(ctx context.Context, url string) ([]b
 
 		return nil, fmt.Errorf("received non-OK HTTP status: %d", resp.StatusCode)
 	}
-}
-
-func (rc *chainRegistryClient) extractValidator(targetValidator string, validators []Validator) (*Validator, error) {
-	for _, validator := range validators {
-		if strings.EqualFold(targetValidator, validator.Name) {
-			return &validator, nil
-		}
-	}
-	return nil, fmt.Errorf("unable to find a validator with name \"%s\"", targetValidator)
 }

--- a/cosmos/chain-registry/registry_test.go
+++ b/cosmos/chain-registry/registry_test.go
@@ -10,8 +10,11 @@ import (
 	"github.com/tessellated-io/pickaxe/log"
 )
 
+const chainsBaseUrl = "https://planetarium.tessellated.io/v1/chains"
+const validatorsBaseUrl = "https://planetarium.tessellated.io/v1/validators"
+
 func TestCanRetrieveChain(t *testing.T) {
-	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel), "https://chain-registry.tessellated.io")
+	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel), chainsBaseUrl, validatorsBaseUrl)
 
 	hubInfo, err := client.ChainInfo(context.Background(), "cosmoshub")
 	assert.Nil(t, err, "error should be nil")
@@ -20,14 +23,14 @@ func TestCanRetrieveChain(t *testing.T) {
 }
 
 func TestCanRetrieveAssets(t *testing.T) {
-	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel), "https://chain-registry.tessellated.io")
+	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel), chainsBaseUrl, validatorsBaseUrl)
 
 	_, err := client.AssetList(context.Background(), "cosmoshub")
 	assert.Nil(t, err, "error should be nil")
 }
 
 func TestCanRetrieveAllChains(t *testing.T) {
-	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel), "https://chain-registry.tessellated.io")
+	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel), chainsBaseUrl, validatorsBaseUrl)
 
 	_, err := client.AllChainNames(context.Background())
 	assert.Nil(t, err, "error should be nil")

--- a/cosmos/chain-registry/registry_test.go
+++ b/cosmos/chain-registry/registry_test.go
@@ -1,0 +1,20 @@
+package registry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	registry "github.com/tessellated-io/pickaxe/cosmos/chain-registry"
+	"github.com/tessellated-io/pickaxe/log"
+)
+
+func TestChainRegistryIsAlive(t *testing.T) {
+	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel))
+
+	hubInfo, err := client.ChainInfo(context.Background(), "cosmoshub")
+	assert.Nil(t, err, "error should be nil")
+
+	assert.Equal(t, hubInfo.ChainID, "cosmoshub-4", "incorrect chain id")
+}

--- a/cosmos/chain-registry/registry_test.go
+++ b/cosmos/chain-registry/registry_test.go
@@ -10,11 +10,25 @@ import (
 	"github.com/tessellated-io/pickaxe/log"
 )
 
-func TestChainRegistryIsAlive(t *testing.T) {
-	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel))
+func TestCanRetrieveChain(t *testing.T) {
+	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel), "https://chain-registry.tessellated.io")
 
 	hubInfo, err := client.ChainInfo(context.Background(), "cosmoshub")
 	assert.Nil(t, err, "error should be nil")
 
 	assert.Equal(t, hubInfo.ChainID, "cosmoshub-4", "incorrect chain id")
+}
+
+func TestCanRetrieveAssets(t *testing.T) {
+	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel), "https://chain-registry.tessellated.io")
+
+	_, err := client.AssetList(context.Background(), "cosmoshub")
+	assert.Nil(t, err, "error should be nil")
+}
+
+func TestCanRetrieveAllChains(t *testing.T) {
+	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel), "https://chain-registry.tessellated.io")
+
+	_, err := client.AllChainNames(context.Background())
+	assert.Nil(t, err, "error should be nil")
 }

--- a/cosmos/chain-registry/registry_test.go
+++ b/cosmos/chain-registry/registry_test.go
@@ -35,3 +35,10 @@ func TestCanRetrieveAllChains(t *testing.T) {
 	_, err := client.AllChainNames(context.Background())
 	assert.Nil(t, err, "error should be nil")
 }
+
+func TestCanRetrieveValidator(t *testing.T) {
+	client := registry.NewChainRegistryClient(log.NewLogger(zerolog.FatalLevel), chainsBaseUrl, validatorsBaseUrl)
+
+	_, err := client.Validator(context.Background(), "tessellated")
+	assert.Nil(t, err, "error should be nil")
+}

--- a/cosmos/chain-registry/types.go
+++ b/cosmos/chain-registry/types.go
@@ -179,21 +179,13 @@ type RestakeInfo struct {
 }
 
 type Validator struct {
-	Path       string        `json:"path"`
-	Name       string        `json:"name"`
-	Identity   string        `json:"identity"`
-	TotalUSD   float64       `json:"total_usd"`
-	TotalUsers int           `json:"total_users"`
-	Chains     []RestakeInfo `json:"chains"`
+	Name   string        `json:"name"`
+	Chains []RestakeInfo `json:"chains"`
 }
 
-type Response struct {
-	Validators []Validator `json:"validators"`
-}
-
-func parseValidatorRegistryResponse(responseBytes []byte) (*Response, error) {
+func parseValidator(responseBytes []byte) (*Validator, error) {
 	// Unmarshal JSON data
-	var response Response
+	var response Validator
 	if err := json.Unmarshal(responseBytes, &response); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Planetarium is a simple server for the chain registry
- Other public end points time out, go down, or misbehave
- Other public endpoints have inconsistent APIs
- This puts us fully in control of our destiny WRT having working registry clients