### PR TITLE
Fix NPE when printing broadcast result

### DIFF
--- a/cosmos/tx/tx_broadcaster.go
+++ b/cosmos/tx/tx_broadcaster.go
@@ -77,7 +77,7 @@ func (b *Broadcaster) SignAndBroadcast(ctx context.Context, msgs []sdk.Msg) (txH
 
 		// Attempt to sign and broadcast
 		broadcastResult, broadcastErr := b.wrapped.signAndBroadcast(ctx, msgs)
-		logger := b.logger.With("tx_hash", txHash, "error", broadcastErr.Error(), "broadcast_result", broadcastResult.String())
+		logger := b.logger.With("tx_hash", txHash, "error", broadcastErr, "broadcast_result", broadcastResult.String())
 
 		logger.Debug("broadcaster::received from signAndBroadcast")
 		if broadcastErr != nil {


### PR DESCRIPTION
`broadcastErr` can be `nil`, which causes an NPE and crashes processes